### PR TITLE
Fix env name and handle missing numpy

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: base
+name: matchame-env
 channels:
   - defaults
   - https://repo.anaconda.com/pkgs/main
@@ -530,4 +530,3 @@ dependencies:
   - zope.interface=5.4.0
   - zstandard=0.23.0
   - zstd=1.5.6
-prefix: /opt/anaconda3

--- a/main.py
+++ b/main.py
@@ -1,8 +1,22 @@
 # main.py
 import sys
-import numpy as np
 
-print("Conda environment is working!")
-print(f"Python executable: {sys.executable}")
-print(f"Numpy version: {np.__version__}")
-print("creating a branch")
+try:
+    import numpy as np
+except ModuleNotFoundError:
+    np = None
+    print("Numpy is not installed. Continuing without it.")
+
+
+def main():
+    """Entry point for the MatchaMe demo script."""
+    print("Conda environment is working!")
+    print(f"Python executable: {sys.executable}")
+    if np is not None:
+        print(f"Numpy version: {np.__version__}")
+    else:
+        print("Numpy not available")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- update conda environment name and remove prefix
- make main.py resilient if numpy isn't installed

## Testing
- `python main.py`