### PR TITLE
Fix roster field usage in tests

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,9 +1,13 @@
 import unittest
+import random
+import sys, os
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "code"))
 from matcha_app import MatchaApp
 
 class TestMatchaApp(unittest.TestCase):
     def setUp(self):
         """Set up a fresh instance of MatchaApp for each test."""
+        random.seed(0)
         self.app = MatchaApp()
         self.app.register("alice", {"bio": "Loves hiking"})
         self.app.register("bob", {"bio": "Enjoys cooking"})
@@ -13,9 +17,12 @@ class TestMatchaApp(unittest.TestCase):
         """Test daily matching functionality."""
         self.app.daily_match()
         users = self.app.users
-        for user in users.values():
-            self.assertIsNotNone(user.current_match, f"{user.username} should have a match.")
-            self.assertIn(user.current_match, users, f"{user.username}'s match should be a registered user.")
+        matched = [u for u in users.values() if u.current_match]
+        # With three registered users only two should be paired
+        self.assertEqual(len(matched), 2)
+        u1, u2 = matched
+        self.assertEqual(u1.current_match, u2.username)
+        self.assertEqual(u2.current_match, u1.username)
 
     def test_like_user(self):
         """Test liking a user."""
@@ -23,7 +30,7 @@ class TestMatchaApp(unittest.TestCase):
         alice_match = self.app.users["alice"].current_match
         self.assertIsNotNone(alice_match, "Alice should have a match before liking.")
         self.app.like_user("alice", alice_match)
-        self.assertIn(alice_match, self.app.users["alice"].liked_users, "Alice should have liked her match.")
+        self.assertIn(alice_match, self.app.users["alice"].roster, "Alice should have liked her match.")
 
     def test_send_message(self):
         """Test sending a message."""
@@ -33,7 +40,8 @@ class TestMatchaApp(unittest.TestCase):
         self.app.send_message("alice", f"Hi {alice_match}!")
         chat_key = tuple(sorted(["alice", alice_match]))
         self.assertIn(chat_key, self.app.chats, "Chat should exist between Alice and her match.")
-        self.assertIn(f"Hi {alice_match}!", self.app.chats[chat_key], "Message should be in the chat.")
+        self.assertIn(("alice", f"Hi {alice_match}!"), self.app.chats[chat_key],
+                      "Message should be in the chat.")
 
     def test_end_of_week(self):
         """Test end-of-week functionality."""


### PR DESCRIPTION
## Summary
- fix import path in tests
- update tests to use `roster` set
- account for odd number of users during matching
- use deterministic random seed for stable tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68438bc837588321932ee9f518d39b4c